### PR TITLE
Fix installation error caused by binary naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ _INSTDIR=${DESTDIR}${PREFIX}
 BINDIR?=${_INSTDIR}/bin
 MANDIR?=${_INSTDIR}/share/man
 APP=devc
+TARGET=""
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	TARGET=linux
+endif
+ifeq ($(UNAME_S),Darwin)
+	TARGET=darwin
+endif
 
 .PHONY: all
 all: build
@@ -11,8 +20,7 @@ all: build
 ## build: Build the application
 build:
 	@echo "Building..."
-	@env GOOS=linux GOARCH=amd64 go build -mod vendor -o build/${APP}-linux-amd64 main.go
-	@env GOOS=darwin GOARCH=amd64 go build -mod vendor -o build/${APP}-darwin-amd64 main.go
+	@env GOOS=${TARGET} GOARCH=amd64 go build -mod vendor -o build/${APP}-${TARGET}-amd64 main.go
 
 .PHONY: check
 ## check: Check that the build is working
@@ -23,8 +31,9 @@ check:
 ## install: Install the application
 install:
 	@echo "Installing..."
+	@cp build/${APP}-${TARGET}-amd64 build/${APP}
 	@mkdir -p ${BINDIR}
-	@install -t ${BINDIR}/ ${APP}
+	@install -t ${BINDIR}/ build/${APP}
 
 .PHONY: uninstall
 ## uninstall: Uninstall the application


### PR DESCRIPTION
The updated makefile generates binary only for target platform, and then
installs it with a proper name.