### PR TITLE
Fix build.context relative to wrong directory

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -21,7 +21,7 @@ var buildCmd = &cobra.Command{
 			buildDocker := docker.New()
 			buildDocker.SetVerbose(rootVerbose)
 			buildDocker.SetDockerfile(".devcontainer/" + rootConfig.GetString("build.dockerfile"))
-			buildDocker.SetContext(rootConfig.GetString("build.context"))
+			buildDocker.SetContext(".devcontainer/" + rootConfig.GetString("build.context"))
 			buildDocker.SetArgs(buildGetDockerArgs(rootConfig))
 			buildDocker.Build()
 		}


### PR DESCRIPTION
Accoring to https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_image-or-dockerfile-specific-properties `build.context` should be relative to `devcontainer.json`

This fixes #16 